### PR TITLE
Fix dbis repository url

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -45,7 +45,7 @@
 	<target name="download-ivy">
 		<mkdir dir="${ivy.jar.dir}" />
 		<echo message="installing ivy..." />
-		<get src="http://repo1.maven.org/maven2/org/apache/ivy/ivy/${ivy.install.version}/ivy-${ivy.install.version}.jar" dest="${ivy.jar.file}" usetimestamp="true" skipexisting="true" />
+		<get src="https://repo1.maven.org/maven2/org/apache/ivy/ivy/${ivy.install.version}/ivy-${ivy.install.version}.jar" dest="${ivy.jar.file}" usetimestamp="true" skipexisting="true" />
 	</target>
 
 	<!-- Try to load Ivy here from local Ivy directory -->
@@ -62,7 +62,7 @@
 		<mkdir dir="${lib}" />
 		<mkdir dir="${service}" />
 		<ivy:settings>
-			<credentials host="role.dbis.rwth-aachen.de:9911/archiva" realm="Repository internal" />
+			<credentials host="archiva.dbis.rwth-aachen.de:9911" realm="Repository internal" />
 		</ivy:settings>
     	<ivy:retrieve type="jar, bundle" conf="platform" pattern="${lib}/[artifact]-[revision].[ext]"/>
     	<ivy:retrieve type="jar, bundle" conf="bundle" pattern="${servicelib}/[artifact]-[revision].[ext]"/>

--- a/etc/ivy/ivysettings.xml
+++ b/etc/ivy/ivysettings.xml
@@ -6,7 +6,7 @@
       <ibiblio name="acis-internal" m2compatible="true"
         root="https://archiva.dbis.rwth-aachen.de:9911/repository/internal/" />
       <ibiblio name="acis-snapshots" m2compatible="true"
-        root="http://archiva.dbis.rwth-aachen.de:9911/repository/snapshots/" />
+        root="https://archiva.dbis.rwth-aachen.de:9911/repository/snapshots/" />
     </chain>
   </resolvers>
 </ivysettings>

--- a/etc/ivy/ivysettings.xml
+++ b/etc/ivy/ivysettings.xml
@@ -4,9 +4,9 @@
     <chain name="chain">
       <ibiblio name="central" m2compatible="true" />
       <ibiblio name="acis-internal" m2compatible="true"
-        root="http://role.dbis.rwth-aachen.de:9911/archiva/repository/internal/" />
+        root="https://archiva.dbis.rwth-aachen.de:9911/repository/internal/" />
       <ibiblio name="acis-snapshots" m2compatible="true"
-        root="http://role.dbis.rwth-aachen.de:9911/archiva/repository/snapshots/" />
+        root="http://archiva.dbis.rwth-aachen.de:9911/repository/snapshots/" />
     </chain>
   </resolvers>
 </ivysettings>


### PR DESCRIPTION
To be able to run the build tasks of the project, the repository urls need to be fixed. However, the project does not get all dependencies, which are need, e.g. from i5.las2peer.api.* and the junit tests are also failing at the moment.